### PR TITLE
Pass `SW_NORMAL` to `ShellExecute`

### DIFF
--- a/src/DesignerVersionChooser.cpp
+++ b/src/DesignerVersionChooser.cpp
@@ -125,7 +125,7 @@ VOID LaunchDesigner(bool debugMode)
         commandLine += std::wstring(L"-d ");
     }
     commandLine.append(szCommandLine);
-    ShellExecute(NULL, NULL, path.c_str(), commandLine.data(), directory.c_str(), 0);
+    ShellExecute(NULL, NULL, path.c_str(), commandLine.data(), directory.c_str(), SW_NORMAL);
 }
 
 
@@ -133,7 +133,7 @@ VOID UninstallDesigner()
 {
     int selItem = (INT)SendMessage(hwList, LB_GETCURSEL, 0, 0);
     std::wstring path = mList.at(selItem).uninstallerPath();
-    ShellExecute(NULL, NULL, path.c_str(), NULL, NULL, 0);
+    ShellExecute(NULL, NULL, path.c_str(), NULL, NULL, SW_NORMAL);
 }
 
 


### PR DESCRIPTION
The use of ShellExecute to open the target executable was passing `0` for the `nShowCmd` parameter.
`0` is defined as `SW_HIDE`.
This commit replaces that with `SW_NORMAL` so that the target executable is never hidden.