### PR TITLE
Improvements to OK button

### DIFF
--- a/src/DesignerVersionChooser.cpp
+++ b/src/DesignerVersionChooser.cpp
@@ -114,18 +114,21 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    return TRUE;
 }
 
-VOID LaunchDesigner(bool debugMode)
+VOID LaunchDesigner(const bool debugMode)
 {
-    int selItem = (INT)SendMessage(hwList, LB_GETCURSEL, 0, 0);
-    std::wstring path = mList.at(selItem).executablePath();
-    std::wstring directory = mList.at(selItem).directoryPath();
-    std::wstring commandLine;
-    if(debugMode)
+    const auto selItem = static_cast<INT>(SendMessage(hwList, LB_GETCURSEL, 0, 0));
+    if ((selItem >= 0) && (mList.size() > selItem))
     {
-        commandLine += std::wstring(L"-d ");
+        const auto path = mList.at(selItem).executablePath();
+        const auto directory = mList.at(selItem).directoryPath();
+        std::wstring commandLine;
+        if (debugMode)
+        {
+            commandLine += std::wstring(L"-d ");
+        }
+        commandLine.append(szCommandLine);
+        ShellExecute(NULL, NULL, path.c_str(), commandLine.data(), directory.c_str(), SW_NORMAL);
     }
-    commandLine.append(szCommandLine);
-    ShellExecute(NULL, NULL, path.c_str(), commandLine.data(), directory.c_str(), SW_NORMAL);
 }
 
 

--- a/src/DesignerVersionChooser.cpp
+++ b/src/DesignerVersionChooser.cpp
@@ -154,6 +154,8 @@ INT_PTR CALLBACK MessageHandler(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
     {
         case WM_INITDIALOG:
         {
+            // Disable ok button
+            EnableWindow(GetDlgItem(hDlg, IDOK), false);
 
             // Add items to list.
             hwList = GetDlgItem(hDlg, IDC_LIST1);
@@ -202,6 +204,14 @@ INT_PTR CALLBACK MessageHandler(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
                         const bool debug = (GetKeyState(VK_CONTROL) & 0x8000); // Control held down
                         LaunchDesigner(debug);
                         EndDialog(hDlg, LOWORD(wParam));
+                        return static_cast<INT_PTR>(TRUE);
+                    }
+
+                    case LBN_SELCHANGE:
+                    {
+                        // Enable OK button only if something is selected
+                        const auto selItem = static_cast<INT>(SendMessage(hwList, LB_GETCURSEL, 0, 0));
+                        EnableWindow(GetDlgItem(hDlg, IDOK), (selItem >= 0));
                         return static_cast<INT_PTR>(TRUE);
                     }
                 }
@@ -279,6 +289,7 @@ INT_PTR CALLBACK MessageHandler(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
                         selItem = (count - 1);
                     }
                     SendMessage(hwList, LB_SETCURSEL, static_cast<WPARAM>(selItem), 0);
+                    EnableWindow(GetDlgItem(hDlg, IDOK), (selItem >= 0));
                     return retAllHandled;
                 }
 
@@ -290,6 +301,7 @@ INT_PTR CALLBACK MessageHandler(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
                         selItem = 0;
                     }
                     SendMessage(hwList, LB_SETCURSEL, static_cast<WPARAM>(selItem), 0);
+                    EnableWindow(GetDlgItem(hDlg, IDOK), (selItem >= 0));
                     return retAllHandled;
                 }
             }


### PR DESCRIPTION
Fixes a crash when the OK button is pressed with nothing selected, but also removes this possibly occurring by disabling the OK button until something is selected. 

Also minor refactors on touched and surrounding code to make more C++ style.